### PR TITLE
[FEAT]: added service to query the device FW version

### DIFF
--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -37,6 +37,7 @@
 #include <nav_msgs/msg/odometry.hpp>
 #include <std_srvs/srv/set_bool.hpp>
 #include <realsense2_camera_srvs/srv/coordinate_req.hpp>
+#include <realsense2_camera_srvs/srv/version_req.hpp>
 
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2_ros/transform_broadcaster.h>
@@ -364,6 +365,10 @@ namespace realsense2_camera
         std::atomic<double> _cam_pitch;
         //DO NOT WRITE THIS VARIABLE, ONLY READ OPERATIONS ARE ALLOWED
         std::atomic<rs2::vertex*> _vertex;
+        rclcpp::Service<realsense2_camera_srvs::srv::VersionReq>::SharedPtr _get_version_srv;
+        bool get_version_cb(realsense2_camera_srvs::srv::VersionReq::Request::SharedPtr req, realsense2_camera_srvs::srv::VersionReq::Response::SharedPtr res);
+        //version service:
+
 
     };//end class
 }

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -352,6 +352,13 @@ void BaseRealSenseNode::setupServices(){
                 this,
                 std::placeholders::_1,
                 std::placeholders::_2));
+    _get_version_srv = _node.create_service<realsense2_camera_srvs::srv::VersionReq>(
+              "get_version",
+              std::bind(
+                &BaseRealSenseNode::get_version_cb,
+                this,
+                std::placeholders::_1,
+                std::placeholders::_2));
     _cam_pitch = atof(getenv("STEREO_ANGLE"));
 }
 
@@ -387,6 +394,11 @@ bool BaseRealSenseNode::get_coords_cb(realsense2_camera_srvs::srv::CoordinateReq
     res -> xyz_coordinate = _pixel_requested_coords;
     return true;
     
+}
+
+bool BaseRealSenseNode::get_version_cb(realsense2_camera_srvs::srv::VersionReq::Request::SharedPtr req, realsense2_camera_srvs::srv::VersionReq::Response::SharedPtr res){
+    res->version=_dev.get_info(RS2_CAMERA_INFO_FIRMWARE_VERSION);
+    return true;
 }
 
 void BaseRealSenseNode::runFirstFrameInitialization(rs2_stream stream_type)

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -2395,7 +2395,7 @@ void BaseRealSenseNode::publishPointCloud(rs2::points pc, const rclcpp::Time& t,
         {
             warn_count++;
             std::string texture_source_name = _pointcloud_filter->get_option_value_description(rs2_option::RS2_OPTION_STREAM_FILTER, static_cast<float>(texture_source_id));
-            ROS_WARN_STREAM_COND(warn_count == DISPLAY_WARN_NUMBER, "No stream match for pointcloud chosen texture " << texture_source_name);
+            // ROS_WARN_STREAM_COND(warn_count == DISPLAY_WARN_NUMBER, "No stream match for pointcloud chosen texture " << texture_source_name);
             return;
         }
         warn_count = 0;

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -2395,7 +2395,7 @@ void BaseRealSenseNode::publishPointCloud(rs2::points pc, const rclcpp::Time& t,
         {
             warn_count++;
             std::string texture_source_name = _pointcloud_filter->get_option_value_description(rs2_option::RS2_OPTION_STREAM_FILTER, static_cast<float>(texture_source_id));
-            // ROS_WARN_STREAM_COND(warn_count == DISPLAY_WARN_NUMBER, "No stream match for pointcloud chosen texture " << texture_source_name);
+            ROS_WARN_STREAM_COND(warn_count == DISPLAY_WARN_NUMBER, "No stream match for pointcloud chosen texture " << texture_source_name);
             return;
         }
         warn_count = 0;

--- a/realsense2_camera_srvs/CMakeLists.txt
+++ b/realsense2_camera_srvs/CMakeLists.txt
@@ -37,6 +37,7 @@ endif()
 # Including services
 set(SRV_FILES
   "srv/CoordinateReq.srv"
+  "srv/VersionReq.srv"
 )
 
 # Message generation

--- a/realsense2_camera_srvs/srv/VersionReq.srv
+++ b/realsense2_camera_srvs/srv/VersionReq.srv
@@ -1,0 +1,2 @@
+---
+string version


### PR DESCRIPTION
In this PR I added a service to query the firmware version of the connected camera. To test it type in a terminal `ros2 service call /camera/get_version realsense2_camera_srvs/VersionReq`