### PR TITLE
Added service to get the pixel representation of a given point

### DIFF
--- a/realsense2_camera/CMakeLists.txt
+++ b/realsense2_camera/CMakeLists.txt
@@ -98,6 +98,7 @@ find_package(geometry_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2 REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
 find_package(realsense2_camera_srvs REQUIRED)
 
 find_package(realsense2 2.45.0)
@@ -168,6 +169,7 @@ set(dependencies
   tf2
   realsense2
   tf2_ros
+  tf2_geometry_msgs
   realsense2_camera_srvs 
 )
 
@@ -219,6 +221,7 @@ if(BUILD_TESTING)
     OpenCV
     rclcpp
     sensor_msgs
+    geometry_msgs
     nav_msgs
     tf2
     tf2_ros)

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -37,6 +37,7 @@
 #include <nav_msgs/msg/odometry.hpp>
 #include <std_srvs/srv/set_bool.hpp>
 #include <realsense2_camera_srvs/srv/coordinate_req.hpp>
+#include <realsense2_camera_srvs/srv/pixel_req.hpp>
 #include <realsense2_camera_srvs/srv/version_req.hpp>
 
 #include <tf2/LinearMath/Quaternion.h>
@@ -361,13 +362,16 @@ namespace realsense2_camera
         //coordinate service
         rclcpp::Service<realsense2_camera_srvs::srv::CoordinateReq>::SharedPtr _get_coords_srv;
         bool get_coords_cb(realsense2_camera_srvs::srv::CoordinateReq::Request::SharedPtr req, realsense2_camera_srvs::srv::CoordinateReq::Response::SharedPtr res);
-        void setupServices();
         std::atomic<double> _cam_pitch;
         //DO NOT WRITE THIS VARIABLE, ONLY READ OPERATIONS ARE ALLOWED
         std::atomic<rs2::vertex*> _vertex;
+        //version service:
         rclcpp::Service<realsense2_camera_srvs::srv::VersionReq>::SharedPtr _get_version_srv;
         bool get_version_cb(realsense2_camera_srvs::srv::VersionReq::Request::SharedPtr req, realsense2_camera_srvs::srv::VersionReq::Response::SharedPtr res);
-        //version service:
+        //pixel service
+        rclcpp::Service<realsense2_camera_srvs::srv::PixelReq>::SharedPtr _get_pixel_srv;
+        bool get_pixel_cb(realsense2_camera_srvs::srv::PixelReq::Request::SharedPtr req, realsense2_camera_srvs::srv::PixelReq::Response::SharedPtr res);
+        void setupServices();
 
 
     };//end class

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -43,6 +43,8 @@
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2_ros/transform_broadcaster.h>
 #include <tf2_ros/static_transform_broadcaster.h>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
 #include <eigen3/Eigen/Geometry>
 #include <condition_variable>
 
@@ -371,6 +373,8 @@ namespace realsense2_camera
         //pixel service
         rclcpp::Service<realsense2_camera_srvs::srv::PixelReq>::SharedPtr _get_pixel_srv;
         bool get_pixel_cb(realsense2_camera_srvs::srv::PixelReq::Request::SharedPtr req, realsense2_camera_srvs::srv::PixelReq::Response::SharedPtr res);
+        std::unique_ptr<tf2_ros::Buffer> _buffer_tf2;
+        std::shared_ptr<tf2_ros::TransformListener> _listener_tf2;
         void setupServices();
 
 

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -33,6 +33,7 @@
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <sensor_msgs/point_cloud2_iterator.hpp>
 #include <geometry_msgs/msg/point.hpp>
+#include <geometry_msgs/msg/point_stamped.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <std_srvs/srv/set_bool.hpp>
@@ -45,6 +46,8 @@
 #include <tf2_ros/static_transform_broadcaster.h>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
+#include "tf2_ros/message_filter.h"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.h"
 #include <eigen3/Eigen/Geometry>
 #include <condition_variable>
 

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -414,8 +414,19 @@ bool BaseRealSenseNode::get_version_cb(realsense2_camera_srvs::srv::VersionReq::
 
 bool BaseRealSenseNode::get_pixel_cb(realsense2_camera_srvs::srv::PixelReq::Request::SharedPtr req, realsense2_camera_srvs::srv::PixelReq::Response::SharedPtr res)
 {
-    for(auto pixel: req->points_requested)
+    std::cout << "received pixel request";
+    for(auto point: req->points_requested)
     {
+        geometry_msgs::msg::PointStamped transformed_point = point;
+        try
+        {
+            _buffer_tf2->transform(point, transformed_point, "camera_link");
+        }
+        catch (tf2::TransformException &ex) 
+        {
+            ROS_WARN("%s",ex.what());
+        }
+        
         //std::cout << pixel << std::endl;
     }
 }

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -142,6 +142,10 @@ BaseRealSenseNode::BaseRealSenseNode(rclcpp::Node& node,
 
     _monitor_options = {RS2_OPTION_ASIC_TEMPERATURE, RS2_OPTION_PROJECTOR_TEMPERATURE};
 
+    // kiwi added
+    _buffer_tf2 = std::make_unique<tf2_ros::Buffer>(_node.get_clock());
+    _listener_tf2 = std::make_shared<tf2_ros::TransformListener>(*_buffer_tf2);
+
     try
     {
         publishTopics();
@@ -346,20 +350,27 @@ void BaseRealSenseNode::publishTopics()
 void BaseRealSenseNode::setupServices(){
     // create a service named /camera/get_coords
     _get_coords_srv = _node.create_service<realsense2_camera_srvs::srv::CoordinateReq>(
-              "get_coords",
-              std::bind(
+            "get_coords",
+            std::bind(
                 &BaseRealSenseNode::get_coords_cb,
                 this,
                 std::placeholders::_1,
                 std::placeholders::_2));
     _get_version_srv = _node.create_service<realsense2_camera_srvs::srv::VersionReq>(
-              "get_version",
-              std::bind(
+            "get_version",
+            std::bind(
                 &BaseRealSenseNode::get_version_cb,
                 this,
                 std::placeholders::_1,
                 std::placeholders::_2));
     _cam_pitch = atof(getenv("STEREO_ANGLE"));
+    _get_pixel_srv = _node.create_service<realsense2_camera_srvs::srv::PixelReq>(
+        "get_pixel",
+        std::bind(
+                &BaseRealSenseNode::get_pixel_cb,
+                this,
+                std::placeholders::_1,
+                std::placeholders::_2));
 }
 
 bool BaseRealSenseNode::get_coords_cb(realsense2_camera_srvs::srv::CoordinateReq::Request::SharedPtr req, realsense2_camera_srvs::srv::CoordinateReq::Response::SharedPtr res){
@@ -399,6 +410,14 @@ bool BaseRealSenseNode::get_coords_cb(realsense2_camera_srvs::srv::CoordinateReq
 bool BaseRealSenseNode::get_version_cb(realsense2_camera_srvs::srv::VersionReq::Request::SharedPtr req, realsense2_camera_srvs::srv::VersionReq::Response::SharedPtr res){
     res->version=_dev.get_info(RS2_CAMERA_INFO_FIRMWARE_VERSION);
     return true;
+}
+
+bool BaseRealSenseNode::get_pixel_cb(realsense2_camera_srvs::srv::PixelReq::Request::SharedPtr req, realsense2_camera_srvs::srv::PixelReq::Response::SharedPtr res)
+{
+    for(auto pixel: req->points_requested)
+    {
+        //std::cout << pixel << std::endl;
+    }
 }
 
 void BaseRealSenseNode::runFirstFrameInitialization(rs2_stream stream_type)

--- a/realsense2_camera_srvs/CMakeLists.txt
+++ b/realsense2_camera_srvs/CMakeLists.txt
@@ -38,6 +38,7 @@ endif()
 set(SRV_FILES
   "srv/CoordinateReq.srv"
   "srv/VersionReq.srv"
+  "srv/PixelReq.srv"
 )
 
 # Message generation

--- a/realsense2_camera_srvs/srv/PixelReq.srv
+++ b/realsense2_camera_srvs/srv/PixelReq.srv
@@ -1,0 +1,3 @@
+geometry_msgs/PointStamped[] points_requested
+---
+geometry_msgs/Point[] pixels


### PR DESCRIPTION
In this PR I implemented a service to get the pixel representation of a given real world point inside the stereo camera. This service takes in a list of geometry_msgs::PointStamped which reference system is looked up in the tf buffer and translated to `camera_color_optical_frame`  and then converted using the camera intrinsics. It returns a list of geometry_msgs::Point with the requested pixels.