### PR TITLE
[ADD]: Service for reporting the camera Pitch 

### DIFF
--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -45,6 +45,7 @@
 #include <realsense2_camera_srvs/srv/coordinate_req.hpp>
 #include <realsense2_camera_srvs/srv/pixel_req.hpp>
 #include <realsense2_camera_srvs/srv/version_req.hpp>
+#include <realsense2_camera_srvs/srv/camera_pitch_req.hpp>
 
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2_ros/transform_broadcaster.h>
@@ -400,6 +401,9 @@ namespace realsense2_camera
         bool get_pixel_cb(realsense2_camera_srvs::srv::PixelReq::Request::SharedPtr req, realsense2_camera_srvs::srv::PixelReq::Response::SharedPtr res);
         std::unique_ptr<tf2_ros::Buffer> _buffer_tf2;
         std::shared_ptr<tf2_ros::TransformListener> _listener_tf2;
+        //get pitch service
+        rclcpp::Service<realsense2_camera_srvs::srv::CameraPitchReq>::SharedPtr _get_pitch_srv;
+        bool get_pitch_cb(realsense2_camera_srvs::srv::CameraPitchReq::Request::SharedPtr req, realsense2_camera_srvs::srv::CameraPitchReq::Response::SharedPtr res);
         void setupServices();
 
         // Chassis transform timer for waiting pitch calculation

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -524,6 +524,13 @@ void BaseRealSenseNode::setupServices(){
                 this,
                 std::placeholders::_1,
                 std::placeholders::_2));
+    _get_pitch_srv = _node.create_service<realsense2_camera_srvs::srv::CameraPitchReq>(
+        "get_pitch",
+        std::bind(
+                &BaseRealSenseNode::get_pitch_cb,
+                this,
+                std::placeholders::_1,
+                std::placeholders::_2));
 }
 
 bool BaseRealSenseNode::get_coords_cb(realsense2_camera_srvs::srv::CoordinateReq::Request::SharedPtr req, realsense2_camera_srvs::srv::CoordinateReq::Response::SharedPtr res){
@@ -603,6 +610,12 @@ bool BaseRealSenseNode::get_pixel_cb(realsense2_camera_srvs::srv::PixelReq::Requ
     }
     // std::cout << "responded\n";
     res->pixels = pixels;
+    return true;
+}
+
+bool BaseRealSenseNode::get_pitch_cb(realsense2_camera_srvs::srv::CameraPitchReq::Request::SharedPtr req, realsense2_camera_srvs::srv::CameraPitchReq::Response::SharedPtr res){
+    (void) req;
+    res->pitch=_cam_pitch;
     return true;
 }
 

--- a/realsense2_camera_srvs/CMakeLists.txt
+++ b/realsense2_camera_srvs/CMakeLists.txt
@@ -39,6 +39,7 @@ set(SRV_FILES
   "srv/CoordinateReq.srv"
   "srv/VersionReq.srv"
   "srv/PixelReq.srv"
+  "srv/CameraPitchReq.srv"
 )
 
 # Message generation

--- a/realsense2_camera_srvs/srv/CameraPitchReq.srv
+++ b/realsense2_camera_srvs/srv/CameraPitchReq.srv
@@ -1,0 +1,2 @@
+---
+float32 pitch


### PR DESCRIPTION
In this PR a new service is added for reporting the pitch value of the Real Sense camera.  For testing it, you can just use the following command:

`ros2 service call /camera/get_pitch realsense2_camera_srvs/srv/CameraPitchReq`