### PR TITLE
 [Diagnostics] Change hardware id to "realsense"

### DIFF
--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -1214,7 +1214,7 @@ void BaseRealSenseNode::startDiagnosticsUpdater()
         ROS_INFO_STREAM("Publish diagnostics every " << _diagnostics_period << " seconds.");
         _diagnostics_updater = std::make_shared<diagnostic_updater::Updater>(&_node, _diagnostics_period);
 
-        _diagnostics_updater->setHardwareID(serial_no);
+        _diagnostics_updater->setHardwareID("realsense");
 
         _diagnostics_updater->add("Temperatures", [this](diagnostic_updater::DiagnosticStatusWrapper& status)
         {


### PR DESCRIPTION
Change the hardware id from the diagnostics topic to "realsense" instead of the camera serial number, to be able to get the diagnostics for the heartbeat node.