### PR TITLE
Arbitrary publish rates for color and depth topics

### DIFF
--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -57,11 +57,6 @@
 #include <realsense2_camera_srvs/srv/pixel_req.hpp>
 #include <realsense2_camera_srvs/srv/version_req.hpp>
 #include <realsense2_camera_srvs/srv/camera_pitch_req.hpp>
-#include <std_srvs/srv/trigger.hpp>
-#include <realsense2_camera_srvs/srv/coordinate_req.hpp>
-#include <realsense2_camera_srvs/srv/pixel_req.hpp>
-#include <realsense2_camera_srvs/srv/version_req.hpp>
-#include <realsense2_camera_srvs/srv/camera_pitch_req.hpp>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 #include "tf2_ros/message_filter.h"
@@ -356,6 +351,10 @@ namespace realsense2_camera
         float _camera_link_x;
         float _camera_link_y;
         float _camera_link_z;
+        // Stereo color publish rate (if different from default FPS)
+        double _stereo_color_publish_rate;
+        // Stereo depth publish rate (if different from default FPS)
+        double _stereo_depth_publish_rate;
         // Imu accel vars
         std::vector<double> _imu_accel_x_vector;
         std::vector<double> _imu_accel_y_vector;
@@ -396,6 +395,27 @@ namespace realsense2_camera
         //publish camera imu angles
         std::array<double, 2> getImuPitchandRoll();
         void ChassisTransformTmrCb();
+
+        // Stereo color publish rate control
+        rclcpp::TimerBase::SharedPtr _stereo_color_publish_timer;
+        std::mutex _stereo_color_frame_mutex;
+        sensor_msgs::msg::Image::UniquePtr _latest_stereo_color_frame;
+        bool _stereo_color_frame_available;
+        void stereoColorPublishTimerCallback();
+
+        // Stereo depth publish rate control
+        rclcpp::TimerBase::SharedPtr _stereo_depth_publish_timer;
+        std::mutex _stereo_depth_frame_mutex;
+        sensor_msgs::msg::Image::UniquePtr _latest_stereo_depth_frame;
+        bool _stereo_depth_frame_available;
+        void stereoDepthPublishTimerCallback();
+
+        // Stereo pointcloud publish rate control
+        rclcpp::TimerBase::SharedPtr _stereo_pointcloud_publish_timer;
+        std::mutex _stereo_pointcloud_frame_mutex;
+        sensor_msgs::msg::PointCloud2::UniquePtr _latest_stereo_pointcloud_frame;
+        bool _stereo_pointcloud_frame_available;
+        void stereoPointcloudPublishTimerCallback();
 
     };//end class
 }

--- a/realsense2_camera/include/named_filter.h
+++ b/realsense2_camera/include/named_filter.h
@@ -43,7 +43,9 @@ namespace realsense2_camera
             PointcloudFilter(std::shared_ptr<rs2::filter> filter, rclcpp::Node& node, std::shared_ptr<Parameters> parameters, rclcpp::Logger logger, bool is_enabled=false);
         
             void setPublisher();
-            void Publish(rs2::points pc, const rclcpp::Time& t, const rs2::frameset& frameset, const std::string& frame_id);
+            void Publish(rs2::points pc, const rclcpp::Time& t, const rs2::frameset& frameset, const std::string& frame_id, bool publish_immediately = true);
+            rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr getPointcloudPublisher() { return _pointcloud_publisher; }
+            sensor_msgs::msg::PointCloud2 getLatestPointcloudMessage() { return _msg_pointcloud; }
 
             // KIWI: Make it public so we can get it in the get coords service call
             sensor_msgs::msg::PointCloud2 _msg_pointcloud;

--- a/realsense2_camera/include/named_filter.h
+++ b/realsense2_camera/include/named_filter.h
@@ -45,7 +45,7 @@ namespace realsense2_camera
             void setPublisher();
             void Publish(rs2::points pc, const rclcpp::Time& t, const rs2::frameset& frameset, const std::string& frame_id, bool publish_immediately = true);
             rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr getPointcloudPublisher() { return _pointcloud_publisher; }
-            sensor_msgs::msg::PointCloud2 getLatestPointcloudMessage() { return _msg_pointcloud; }
+            sensor_msgs::msg::PointCloud2::UniquePtr getLatestPointcloudMessage() { return std::make_unique<sensor_msgs::msg::PointCloud2>(_msg_pointcloud); }
 
             // KIWI: Make it public so we can get it in the get coords service call
             sensor_msgs::msg::PointCloud2 _msg_pointcloud;

--- a/realsense2_camera/launch/rs_kiwi.launch.py
+++ b/realsense2_camera/launch/rs_kiwi.launch.py
@@ -3,14 +3,13 @@
 
 """Launch realsense2_camera node."""
 import os
-from launch import LaunchDescription
-from ament_index_python.packages import get_package_share_directory
-import launch_ros.actions
-from launch.actions import DeclareLaunchArgument, GroupAction
-from launch.substitutions import LaunchConfiguration, PythonExpression
-from launch.conditions import IfCondition
-from launch_ros.descriptions import ComposableNode
 
+import launch_ros.actions
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, GroupAction
+from launch.conditions import IfCondition
+from launch.substitutions import LaunchConfiguration, PythonExpression
+from launch_ros.descriptions import ComposableNode
 
 configurable_parameters = [{'name': 'camera_name',                  'default': 'camera', 'description': 'camera unique name'},
                            {'name': 'serial_no',                    'default': "''", 'description': 'choose device by serial number'},
@@ -68,6 +67,8 @@ configurable_parameters = [{'name': 'camera_name',                  'default': '
                            {'name': 'camera_link_x',                'default': '0.21', 'description': 'x translation between base frame and camera'},                           
                            {'name': 'camera_link_y',                'default': '-0.041', 'description': 'y translation between base frame and camera'},                           
                            {'name': 'camera_link_z',                'default': '0.404', 'description': 'z translation between base frame and camera'},   
+                           {'name': 'stereo_color_publish_rate',    'default': '-1.0', 'description': 'Custom publish rate for stereo color stream. -1 means use default FPS'},
+                           {'name': 'stereo_depth_publish_rate',    'default': '-1.0', 'description': 'Custom publish rate for stereo depth stream. -1 means use default FPS'},
                            {'name': 'pc_subsample_fct',             'default': '8', 'description': 'Factor used for subsampling the pointcloud. 1 uses the default density'},
                            {'name': 'color_qos',                    'default': 'SENSOR_DATA', 'description': 'QoS profile name'},    
                            {'name': 'confidence_qos',               'default': 'SENSOR_DATA', 'description': 'QoS profile name'},    

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -195,10 +195,9 @@ void BaseRealSenseNode::stereoColorPublishTimerCallback()
         auto color_publisher_it = _image_publishers.find(COLOR);
         if (color_publisher_it != _image_publishers.end())
         {
-            // Create a copy of the latest frame for publishing
-            auto frame_to_publish = std::make_unique<sensor_msgs::msg::Image>(*_latest_stereo_color_frame);
-            frame_to_publish->header.stamp = _node.now();
-            color_publisher_it->second->publish(std::move(frame_to_publish));
+            // Update timestamp and move the frame to avoid copying
+            _latest_stereo_color_frame->header.stamp = _node.now();
+            color_publisher_it->second->publish(std::move(_latest_stereo_color_frame));
         }
     }
 }
@@ -212,10 +211,9 @@ void BaseRealSenseNode::stereoDepthPublishTimerCallback()
         auto depth_publisher_it = _depth_aligned_image_publishers.find(COLOR);
         if (depth_publisher_it != _depth_aligned_image_publishers.end())
         {
-            // Create a copy of the latest frame for publishing
-            auto frame_to_publish = std::make_unique<sensor_msgs::msg::Image>(*_latest_stereo_depth_frame);
-            frame_to_publish->header.stamp = _node.now();
-            depth_publisher_it->second->publish(std::move(frame_to_publish));
+            // Update timestamp and move the frame to avoid copying
+            _latest_stereo_depth_frame->header.stamp = _node.now();
+            depth_publisher_it->second->publish(std::move(_latest_stereo_depth_frame));
         }
     }
 }
@@ -228,10 +226,9 @@ void BaseRealSenseNode::stereoPointcloudPublishTimerCallback()
         // Get the pointcloud publisher from the pc_filter
         if (_pc_filter && _pc_filter->getPointcloudPublisher())
         {
-            // Create a copy of the latest frame for publishing
-            auto frame_to_publish = std::make_unique<sensor_msgs::msg::PointCloud2>(*_latest_stereo_pointcloud_frame);
-            frame_to_publish->header.stamp = _node.now();
-            _pc_filter->getPointcloudPublisher()->publish(std::move(frame_to_publish));
+            // Update timestamp and move the frame to avoid copying
+            _latest_stereo_pointcloud_frame->header.stamp = _node.now();
+            _pc_filter->getPointcloudPublisher()->publish(std::move(_latest_stereo_pointcloud_frame));
         }
     }
 }
@@ -1131,7 +1128,8 @@ void BaseRealSenseNode::publishPointCloud(rs2::points pc, const rclcpp::Time& t,
     if (_stereo_depth_publish_rate > 0.0)
     {
         std::lock_guard<std::mutex> lock(_stereo_pointcloud_frame_mutex);
-        _latest_stereo_pointcloud_frame = std::make_unique<sensor_msgs::msg::PointCloud2>(_pc_filter->getLatestPointcloudMessage());
+        // Move the frame instead of copying to avoid data duplication
+        _latest_stereo_pointcloud_frame = std::move(_pc_filter->getLatestPointcloudMessage());
         _stereo_pointcloud_frame_available = true;
     }
 }
@@ -1260,7 +1258,8 @@ void BaseRealSenseNode::publishFrame(rs2::frame f, const rclcpp::Time& t,
         if (is_color_stream && _stereo_color_publish_rate > 0.0)
         {
             std::lock_guard<std::mutex> lock(_stereo_color_frame_mutex);
-            _latest_stereo_color_frame = std::make_unique<sensor_msgs::msg::Image>(*img);
+            // Move the frame instead of copying to avoid data duplication
+            _latest_stereo_color_frame = std::move(img);
             _stereo_color_frame_available = true;
         }
 
@@ -1268,7 +1267,8 @@ void BaseRealSenseNode::publishFrame(rs2::frame f, const rclcpp::Time& t,
         if (is_depth_stream && _stereo_depth_publish_rate > 0.0)
         {
             std::lock_guard<std::mutex> lock(_stereo_depth_frame_mutex);
-            _latest_stereo_depth_frame = std::make_unique<sensor_msgs::msg::Image>(*img);
+            // Move the frame instead of copying to avoid data duplication
+            _latest_stereo_depth_frame = std::move(img);
             _stereo_depth_frame_available = true;
         }
 

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -86,7 +86,12 @@ BaseRealSenseNode::BaseRealSenseNode(rclcpp::Node& node,
     _is_initialized_time_base(false),
     _sync_frames(SYNC_FRAMES),
     _is_profile_changed(false),
-    _is_align_depth_changed(false)
+    _is_align_depth_changed(false),
+    _stereo_color_publish_rate(-1.0),
+    _stereo_color_frame_available(false),
+    _stereo_depth_publish_rate(-1.0),
+    _stereo_depth_frame_available(false),
+    _stereo_pointcloud_frame_available(false)
 {
 
     // Kiwi added: allow static tf with intra process
@@ -147,7 +152,88 @@ void BaseRealSenseNode::publishTopics()
         _virtualcam = new FakeWebcam("/dev/video" + std::to_string(_color_virtual_cam), 
         _stream_intrinsics[COLOR].width, _stream_intrinsics[COLOR].height);
     }
+
+    // Initialize stereo color publish timer if custom rate is enabled
+    if (_stereo_color_publish_rate > 0.0)
+    {
+        ROS_INFO_STREAM("Stereo color publish rate set to " << _stereo_color_publish_rate << " Hz");
+        _stereo_color_publish_timer = _node.create_wall_timer(
+            std::chrono::milliseconds(static_cast<int>(1000.0 / _stereo_color_publish_rate)),
+            std::bind(&BaseRealSenseNode::stereoColorPublishTimerCallback, this)
+        );
+    }
+
+    // Initialize stereo depth publish timer if custom rate is enabled
+    if (_stereo_depth_publish_rate > 0.0)
+    {
+        ROS_INFO_STREAM("Stereo depth publish rate set to " << _stereo_depth_publish_rate << " Hz");
+        _stereo_depth_publish_timer = _node.create_wall_timer(
+            std::chrono::milliseconds(static_cast<int>(1000.0 / _stereo_depth_publish_rate)),
+            std::bind(&BaseRealSenseNode::stereoDepthPublishTimerCallback, this)
+        );
+    }
+
+    // Initialize stereo pointcloud publish timer if custom rate is enabled
+    if (_stereo_depth_publish_rate > 0.0)
+    {
+        ROS_INFO_STREAM("Stereo pointcloud publish rate set to " << _stereo_depth_publish_rate << " Hz");
+        _stereo_pointcloud_publish_timer = _node.create_wall_timer(
+            std::chrono::milliseconds(static_cast<int>(1000.0 / _stereo_depth_publish_rate)),
+            std::bind(&BaseRealSenseNode::stereoPointcloudPublishTimerCallback, this)
+        );
+    }
+
     ROS_INFO_STREAM("RealSense Node Is Up!");
+}
+
+void BaseRealSenseNode::stereoColorPublishTimerCallback()
+{
+    std::lock_guard<std::mutex> lock(_stereo_color_frame_mutex);
+    if (_stereo_color_frame_available && _latest_stereo_color_frame)
+    {
+        // Find the color stream publisher
+        auto color_publisher_it = _image_publishers.find(COLOR);
+        if (color_publisher_it != _image_publishers.end())
+        {
+            // Create a copy of the latest frame for publishing
+            auto frame_to_publish = std::make_unique<sensor_msgs::msg::Image>(*_latest_stereo_color_frame);
+            frame_to_publish->header.stamp = _node.now();
+            color_publisher_it->second->publish(std::move(frame_to_publish));
+        }
+    }
+}
+
+void BaseRealSenseNode::stereoDepthPublishTimerCallback()
+{
+    std::lock_guard<std::mutex> lock(_stereo_depth_frame_mutex);
+    if (_stereo_depth_frame_available && _latest_stereo_depth_frame)
+    {
+        // Find the depth stream publisher
+        auto depth_publisher_it = _image_publishers.find(DEPTH);
+        if (depth_publisher_it != _image_publishers.end())
+        {
+            // Create a copy of the latest frame for publishing
+            auto frame_to_publish = std::make_unique<sensor_msgs::msg::Image>(*_latest_stereo_depth_frame);
+            frame_to_publish->header.stamp = _node.now();
+            depth_publisher_it->second->publish(std::move(frame_to_publish));
+        }
+    }
+}
+
+void BaseRealSenseNode::stereoPointcloudPublishTimerCallback()
+{
+    std::lock_guard<std::mutex> lock(_stereo_pointcloud_frame_mutex);
+    if (_stereo_pointcloud_frame_available && _latest_stereo_pointcloud_frame)
+    {
+        // Get the pointcloud publisher from the pc_filter
+        if (_pc_filter && _pc_filter->getPointcloudPublisher())
+        {
+            // Create a copy of the latest frame for publishing
+            auto frame_to_publish = std::make_unique<sensor_msgs::msg::PointCloud2>(*_latest_stereo_pointcloud_frame);
+            frame_to_publish->header.stamp = _node.now();
+            _pc_filter->getPointcloudPublisher()->publish(std::move(frame_to_publish));
+        }
+    }
 }
 
 void BaseRealSenseNode::setupFilters()
@@ -1034,7 +1120,20 @@ void BaseRealSenseNode::publishDynamicTransforms()
 void BaseRealSenseNode::publishPointCloud(rs2::points pc, const rclcpp::Time& t, const rs2::frameset& frameset)
 {
     std::string frame_id = (_align_depth_filter->is_enabled() ? OPTICAL_FRAME_ID(COLOR) : OPTICAL_FRAME_ID(DEPTH));
-    _pc_filter->Publish(pc, t, frameset, frame_id);
+    
+    // Determine if we should publish immediately based on custom publish rate
+    bool publish_immediately = !(_stereo_depth_publish_rate > 0.0);
+    
+    // Publish the pointcloud (this will also prepare the message)
+    _pc_filter->Publish(pc, t, frameset, frame_id, publish_immediately);
+    
+    // Store latest stereo pointcloud frame if custom publish rate is enabled
+    if (_stereo_depth_publish_rate > 0.0)
+    {
+        std::lock_guard<std::mutex> lock(_stereo_pointcloud_frame_mutex);
+        _latest_stereo_pointcloud_frame = std::make_unique<sensor_msgs::msg::PointCloud2>(_pc_filter->getLatestPointcloudMessage());
+        _stereo_pointcloud_frame_available = true;
+    }
 }
 
 
@@ -1152,9 +1251,32 @@ void BaseRealSenseNode::publishFrame(rs2::frame f, const rclcpp::Time& t,
         img->width = width;
         img->is_bigendian = false;
         img->step = width * bpp;
+
+        // Store latest stereo color frame if custom publish rate is enabled
+        if (stream == COLOR && _stereo_color_publish_rate > 0.0)
+        {
+            std::lock_guard<std::mutex> lock(_stereo_color_frame_mutex);
+            _latest_stereo_color_frame = std::make_unique<sensor_msgs::msg::Image>(*img);
+            _stereo_color_frame_available = true;
+        }
+
+        // Store latest stereo depth frame if custom publish rate is enabled
+        if (stream == DEPTH && _stereo_depth_publish_rate > 0.0)
+        {
+            std::lock_guard<std::mutex> lock(_stereo_depth_frame_mutex);
+            _latest_stereo_depth_frame = std::make_unique<sensor_msgs::msg::Image>(*img);
+            _stereo_depth_frame_available = true;
+        }
+
         // Transfer the unique pointer ownership to the RMW
         sensor_msgs::msg::Image* msg_address = img.get();
-        image_publisher->publish(std::move(img));
+        
+        // Only publish immediately if custom publish rate is not enabled for color or depth stream
+        if (!(stream == COLOR && _stereo_color_publish_rate > 0.0) && 
+            !(stream == DEPTH && _stereo_depth_publish_rate > 0.0))
+        {
+            image_publisher->publish(std::move(img));
+        }
 
         ROS_DEBUG_STREAM(rs2_stream_to_string(f.get_profile().stream_type()) << " stream published, message address: " << std::hex << msg_address);
     }

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -207,7 +207,7 @@ void BaseRealSenseNode::stereoDepthPublishTimerCallback()
     std::lock_guard<std::mutex> lock(_stereo_depth_frame_mutex);
     if (_stereo_depth_frame_available && _latest_stereo_depth_frame)
     {
-        // Find the depth stream publisher
+        // Find the depth stream publisher, the COLOR publisher is the one that is aligned to the rgb image
         auto depth_publisher_it = _depth_aligned_image_publishers.find(COLOR);
         if (depth_publisher_it != _depth_aligned_image_publishers.end())
         {

--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -209,8 +209,8 @@ void BaseRealSenseNode::stereoDepthPublishTimerCallback()
     if (_stereo_depth_frame_available && _latest_stereo_depth_frame)
     {
         // Find the depth stream publisher
-        auto depth_publisher_it = _image_publishers.find(DEPTH);
-        if (depth_publisher_it != _image_publishers.end())
+        auto depth_publisher_it = _depth_aligned_image_publishers.find(COLOR);
+        if (depth_publisher_it != _depth_aligned_image_publishers.end())
         {
             // Create a copy of the latest frame for publishing
             auto frame_to_publish = std::make_unique<sensor_msgs::msg::Image>(*_latest_stereo_depth_frame);
@@ -1218,6 +1218,10 @@ void BaseRealSenseNode::publishFrame(rs2::frame f, const rclcpp::Time& t,
             // Stream is already disabled.
             return;
         }
+    // We need to check for depth image this way since the it is sent as a color stream
+    bool is_depth_stream = f.is<rs2::depth_frame>() && stream == COLOR;
+    bool is_color_stream = !f.is<rs2::depth_frame>() && stream == COLOR;
+
     auto& info_publisher = info_publishers.at(stream);
     auto& image_publisher = image_publishers.at(stream);
     if(0 != info_publisher->get_subscription_count() ||
@@ -1253,7 +1257,7 @@ void BaseRealSenseNode::publishFrame(rs2::frame f, const rclcpp::Time& t,
         img->step = width * bpp;
 
         // Store latest stereo color frame if custom publish rate is enabled
-        if (stream == COLOR && _stereo_color_publish_rate > 0.0)
+        if (is_color_stream && _stereo_color_publish_rate > 0.0)
         {
             std::lock_guard<std::mutex> lock(_stereo_color_frame_mutex);
             _latest_stereo_color_frame = std::make_unique<sensor_msgs::msg::Image>(*img);
@@ -1261,7 +1265,7 @@ void BaseRealSenseNode::publishFrame(rs2::frame f, const rclcpp::Time& t,
         }
 
         // Store latest stereo depth frame if custom publish rate is enabled
-        if (stream == DEPTH && _stereo_depth_publish_rate > 0.0)
+        if (is_depth_stream && _stereo_depth_publish_rate > 0.0)
         {
             std::lock_guard<std::mutex> lock(_stereo_depth_frame_mutex);
             _latest_stereo_depth_frame = std::make_unique<sensor_msgs::msg::Image>(*img);
@@ -1272,13 +1276,21 @@ void BaseRealSenseNode::publishFrame(rs2::frame f, const rclcpp::Time& t,
         sensor_msgs::msg::Image* msg_address = img.get();
         
         // Only publish immediately if custom publish rate is not enabled for color or depth stream
-        if (!(stream == COLOR && _stereo_color_publish_rate > 0.0) && 
-            !(stream == DEPTH && _stereo_depth_publish_rate > 0.0))
+        if ((is_color_stream && _stereo_color_publish_rate <= 0.0) || 
+            (is_depth_stream && _stereo_depth_publish_rate <= 0.0))
         {
             image_publisher->publish(std::move(img));
         }
 
         ROS_DEBUG_STREAM(rs2_stream_to_string(f.get_profile().stream_type()) << " stream published, message address: " << std::hex << msg_address);
+    }
+    else {
+        if (is_color_stream) {
+            _stereo_color_frame_available = false;
+        }
+        else if (is_depth_stream) {
+            _stereo_depth_frame_available = false;
+        }
     }
     if (is_publishMetadata)
     {

--- a/realsense2_camera/src/named_filter.cpp
+++ b/realsense2_camera/src/named_filter.cpp
@@ -140,7 +140,7 @@ void reverse_memcpy(unsigned char* dst, const unsigned char* src, size_t n)
 
 }
 
-void PointcloudFilter::Publish(rs2::points pc, const rclcpp::Time& t, const rs2::frameset& frameset, const std::string& frame_id)
+void PointcloudFilter::Publish(rs2::points pc, const rclcpp::Time& t, const rs2::frameset& frameset, const std::string& frame_id, bool publish_immediately)
 {
     // moved down so the get coords service can work
     // {
@@ -298,7 +298,7 @@ void PointcloudFilter::Publish(rs2::points pc, const rclcpp::Time& t, const rs2:
     }
     {
         std::lock_guard<std::mutex> lock_guard(_mutex_publisher);
-        if (_pointcloud_publisher)
+        if (_pointcloud_publisher && publish_immediately)
             _pointcloud_publisher->publish(_msg_pointcloud);
     }
 }

--- a/realsense2_camera/src/parameters.cpp
+++ b/realsense2_camera/src/parameters.cpp
@@ -85,6 +85,16 @@ void BaseRealSenseNode::getParameters()
     param_name = std::string("camera_link_z");
     _camera_link_z =  _parameters->setParam<double>(param_name, CAMERA_LINK_Z);
     _parameters_names.push_back(param_name);
+
+    // Kiwi added: stereo color publish rate parameter
+    param_name = std::string("stereo_color_publish_rate");
+    _stereo_color_publish_rate = _parameters->setParam<double>(param_name, -1.0); // -1 means use default FPS
+    _parameters_names.push_back(param_name);
+
+    // Kiwi added: stereo depth publish rate parameter
+    param_name = std::string("stereo_depth_publish_rate");
+    _stereo_depth_publish_rate = _parameters->setParam<double>(param_name, -1.0); // -1 means use default FPS
+    _parameters_names.push_back(param_name);
 }
 
 void BaseRealSenseNode::setDynamicParams()


### PR DESCRIPTION
Adds  2 new parameters to control the actual publish rate of images and pointcloud since natively very weird frame rates are supported (7, 15, 30).
New params:
* stereo_color_publish_rate: controls the rate of the /camera/color/image_raw
* stereo_depth_publish_rate: controls the rate of the /camera/depth/color/points and /camera/aligned_depth_to_color/image_raw